### PR TITLE
Client logging

### DIFF
--- a/httpdumper.go
+++ b/httpdumper.go
@@ -11,7 +11,7 @@ import (
 
 // EchoHandler echos requests back to the client as plain text.
 type EchoHandler struct {
-	log logrus.FieldLogger
+	Log logrus.FieldLogger
 }
 
 func (h *EchoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -19,13 +19,13 @@ func (h *EchoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(w, "bad request, couldn't dump")
-		h.log.WithError(err).Warn("failed to dump request")
+		h.Log.WithError(err).Warn("failed to dump request")
 	}
 	w.Header().Add("Content-Type", "text/plain; charset=utf-8")
 	if _, err := w.Write(rd); err != nil {
-		h.log.WithError(err).Warn("failed to write to client")
+		h.Log.WithError(err).Warn("failed to write to client")
 	}
-	h.log.WithFields(logrus.Fields{
+	h.Log.WithFields(logrus.Fields{
 		"protocol": r.Proto,
 		"method":   r.Method,
 		"url":      r.URL.String(),
@@ -34,7 +34,7 @@ func (h *EchoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 var defaultEchoHandler = &EchoHandler{
-	log: logrus.StandardLogger(),
+	Log: logrus.StandardLogger(),
 }
 
 // Echo the request back to the client as plain text.

--- a/httpdumper_test.go
+++ b/httpdumper_test.go
@@ -33,7 +33,7 @@ func TestEchoHandlerServeHTTP(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	(&EchoHandler{
-		log: discardLogger(t),
+		Log: discardLogger(t),
 	}).ServeHTTP(w, r)
 
 	resp := w.Result()


### PR DESCRIPTION
Add `LoggingTransport` to dump requests and responses on the client side.

Also export member of `EchoHandler` so that type is actually usable outside of the package.