### PR TITLE
Default transport

### DIFF
--- a/httpdumper.go
+++ b/httpdumper.go
@@ -79,3 +79,12 @@ func (t *LoggingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 
 	return resp, err
 }
+
+// DefaultTransport is a LoggingTransport with the defaults for underlying
+// transport and logger.
+func DefaultTransport() http.RoundTripper {
+	return &LoggingTransport{
+		Transport: http.DefaultTransport,
+		Log:       logrus.StandardLogger(),
+	}
+}


### PR DESCRIPTION
`DefaultTransport()` returns a `LoggingTransport` with the defaults for both `Log` and `Transport`.